### PR TITLE
Update routes transform from route names to asterisk version

### DIFF
--- a/packages/wrangler/src/pages/functions/filepath-routing.test.ts
+++ b/packages/wrangler/src/pages/functions/filepath-routing.test.ts
@@ -1,7 +1,10 @@
 import { writeFileSync, mkdirSync } from "fs";
 import { runInTempDir } from "../../__tests__/helpers/run-in-tmp";
 import { toUrlPath } from "../../paths";
-import { compareRoutes, generateConfigFromFileTree } from "./filepath-routing";
+import {
+	compareRoutes,
+	generateConfigFromFileTree,
+} from "../functions/filepath-routing";
 import type { UrlPath } from "../../paths";
 import type { HTTPMethod, RouteConfig } from "./routes";
 

--- a/packages/wrangler/src/pages/functions/routes-to-filter-rules.test.ts
+++ b/packages/wrangler/src/pages/functions/routes-to-filter-rules.test.ts
@@ -1,39 +1,31 @@
-import { toUrlPath } from "../../paths";
-import {
-	convertRouteListToFilterRules,
-	convertRouteToFilterRule,
-	WorkerRouterVersion,
-} from "./routes-to-filter-rules";
+import { convertRouteNamesToAsterisks } from "./routes-to-filter-rules";
 
-describe("routes-to-filter-rules", () => {
-	describe("convertRouteToFilterRule", () => {
-		const convert = (path: string) => convertRouteToFilterRule(toUrlPath(path));
-
-		describe("single input", () => {
-			it("should pass through a single route, no wildcards", () => {
-				expect(convert("/api/foo")).toEqual("/api/foo");
-			});
-			it("should escalate a single param route to a wildcard", () => {
-				expect(convert("/api/:foo")).toEqual("/api/*");
-			});
-			it("should pass through a single wildcard route", () => {
-				expect(convert("/api/:baz*")).toEqual("/api/*");
-			});
+describe("functions routing", () => {
+	describe("single input", () => {
+		it("should handle an empty input", () => {
+			expect(convertRouteNamesToAsterisks([])).toEqual([]);
 		});
-	});
-
-	describe("convertRouteListToFilterRules", () => {
-		const convert = (paths: string[]) =>
-			convertRouteListToFilterRules(paths.map((p) => toUrlPath(p)));
-
-		describe("multiple rules", () => {
-			it("Should deduplicate identical rules", () => {
-				expect(convert(["/api/:baz*", "/api/:foo"])).toEqual({
-					version: WorkerRouterVersion,
-					include: ["/api/*"],
-					exclude: [],
-				});
-			});
+		it("should pass through a single route, no wildcards", () => {
+			expect(convertRouteNamesToAsterisks(["/api/foo"])).toEqual(["/api/foo"]);
+		});
+		it("should escalate a single param route to a wildcard", () => {
+			expect(convertRouteNamesToAsterisks(["/api/:foo"])).toEqual(["/api/*"]);
+		});
+		it("should escalate multiple params to multiple wildcards", () => {
+			expect(
+				convertRouteNamesToAsterisks([
+					"/api/users/:userId/favorites/:favoriteId",
+				])
+			).toEqual(["/api/users/*/favorites/*"]);
+		});
+		it("should handle multiple routes", () => {
+			expect(convertRouteNamesToAsterisks(["/foo/", "/foo/:bar"])).toEqual([
+				"/foo/",
+				"/foo/*",
+			]);
+		});
+		it("should pass through a single wildcard route", () => {
+			expect(convertRouteNamesToAsterisks(["/api/:baz*"])).toEqual(["/api/*"]);
 		});
 	});
 });

--- a/packages/wrangler/src/pages/functions/routes-to-filter-rules.ts
+++ b/packages/wrangler/src/pages/functions/routes-to-filter-rules.ts
@@ -8,16 +8,14 @@ export type WorkerRouter = {
 	exclude: string[];
 };
 
-export function convertRouteToFilterRule(route: UrlPath): string {
-	return route.replace(/:\w+\*?/, "*");
+export function convertRouteNamesToAsterisks(input: string[]): string[] {
+	return input.map((rule) => rule.replace(/:\w+\*?/g, "*"));
 }
 
 export function convertRouteListToFilterRules(routes: UrlPath[]): WorkerRouter {
-	const includeRules = routes.map((route) => convertRouteToFilterRule(route));
-	const uniqueRules = Array.from(new Set(includeRules));
 	return {
 		version: WorkerRouterVersion,
-		include: uniqueRules,
+		include: convertRouteNamesToAsterisks(routes),
 		exclude: [],
 	};
 }


### PR DESCRIPTION
This is because we want the Bumblebee transform service to handle the heavy lifting